### PR TITLE
Add link to glossary.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ Biconomy provides Account Abstraction APIs for a wide range of uses cases and po
 Wallet Connect is an easy way to get started with wallet integration across web3.\
 [Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-appshttps://t.me/appkit_test_ggr_bot)\
 [Reown Docs](https://docs.reown.com/)
+### MOnad Glossary
+[View the Monad Glossary →](./glossary.md)


### PR DESCRIPTION
This PR adds a link to the Monad Glossary in the README so new contributors can find definitions easily.